### PR TITLE
Fixing issue with roll_for_initiative not getting called

### DIFF
--- a/EdgeWare/start.pyw
+++ b/EdgeWare/start.pyw
@@ -532,7 +532,7 @@ def annoyance():
 
 
 # independently attempt to do all active settings with probability equal to their freq value
-def roll_for_initiative(corr_chance: float):
+def roll_for_initiative(corr_chance: float = 0.0): #TODO: Remove default value when corruption gets implemented
     if settings.CORRUPTION_MODE and settings.CORRUPTION_TRIGGER != "Launch":
         corr_chance = corruption_percent()
         if corr_chance > 1.0:


### PR DESCRIPTION
Fixing issue with roll_for_initiative not getting called due to lack of argument from caller side.

Fixed it by making roll_for_initiative's argument corr_chance have a default value. This should probably be removed when corruption gets added