### PR TITLE
Linux: Added window managers; fixed various linux issues

### DIFF
--- a/EdgeWare/utils/linux.py
+++ b/EdgeWare/utils/linux.py
@@ -22,6 +22,8 @@ def set_borderless(root):
 
 def set_wallpaper(wallpaper_path: Path | str):
     global first_run
+    if not 'first_run' in globals():
+        first_run = True
     if isinstance(wallpaper_path, Path):
         wallpaper_path = str(wallpaper_path.absolute())
 

--- a/EdgeWare/utils/linux.py
+++ b/EdgeWare/utils/linux.py
@@ -332,7 +332,11 @@ def _get_desktop_environment():
             "kde",
             "i3",
             "awesome",
-            "hyprland"
+            "Hyprland",
+            "dwm",
+            "xmonad",
+            "bspwm",
+            "sway"
         ]:
             return desktop_session
         ## Special cases ##
@@ -397,6 +401,7 @@ def _wm_set_background(wallpaper_path: Path | str):
     elif session == "wayland":
         wallpaper_setters = [
             "hyprpaper",
+            "swaybg"  # not tested
         ]
     else:
         sys.stderr.write("Unknown session: %s" % session)
@@ -480,6 +485,9 @@ def _wm_set_background(wallpaper_path: Path | str):
                             sys.stderr.write("hyprpaper requires hyprctl.")
                         return
                     args = "hyprctl hyprpaper wallpaper \",%s\"" % wallpaper_path
+                    break
+                case "swaybg":
+                    args = "swaybg -o \"*\" -i %s -m fill" % wallpaper_path
                     break
                 case _:
                     sys.stderr.write("Tell the developer they \"forgot to add a case for %s\"" % setter)

--- a/EdgeWare/utils/linux.py
+++ b/EdgeWare/utils/linux.py
@@ -414,6 +414,7 @@ def _wm_set_background(wallpaper_path: Path | str):
     else:
         sys.stderr.write("Unknown session: %s" % session)
     # perform commands based on the wallpaper setter
+    args = ""
     for setter in wallpaper_setters:
         if shutil.which(setter):
             match setter:
@@ -425,7 +426,6 @@ def _wm_set_background(wallpaper_path: Path | str):
                         if first_run:
                             sys.stderr.write("Couldn't find any x11 displays")
                         return
-                    args = ""
                     for x in s.stdout.readlines():
                         display = x.decode('ascii').strip()
                         args += "nitrogen --head=%s --set-zoom-fill %s && " % (display, wallpaper_path)
@@ -490,4 +490,8 @@ def _wm_set_background(wallpaper_path: Path | str):
                 case _:
                     sys.stderr.write("Tell the developer they \"forgot to add a case for %s\"" % setter)
                     return
+    if not args:
+        if first_run:
+            sys.stderr.write("Couldn't set background.")
+        return
     subprocess.run(args, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/EdgeWare/utils/linux.py
+++ b/EdgeWare/utils/linux.py
@@ -14,7 +14,7 @@ from utils.paths import Defaults, Process
 
 
 def panic_script():
-    subprocess.run("for pid in $(ps -u $USER -ef | grep -E \"python.* *+.pyw\" | awk '{print $2}'); do echo $pid; kill -9 $pid; done", shell=True)
+    subprocess.run("pkill -u $USER -fi -9 \"python.* *+.pyw\"", shell=True)
 
 
 def set_borderless(root):

--- a/EdgeWare/utils/linux.py
+++ b/EdgeWare/utils/linux.py
@@ -415,7 +415,7 @@ def _wm_set_background(wallpaper_path: Path | str):
                     args = ""
                     for x in s.stdout.readlines():
                         display = x.decode('ascii').strip()
-                        args += "nitrogen --head=%s --set-auto %s && " % (display, wallpaper_path)
+                        args += "nitrogen --head=%s --set-zoom-fill %s && " % (display, wallpaper_path)
                     args += ":"  # bash no-op
                     break
                 case "feh":

--- a/EdgeWare/utils/linux.py
+++ b/EdgeWare/utils/linux.py
@@ -319,7 +319,7 @@ def _is_running(process):
     s = subprocess.Popen(["ps", "axw"], stdout=subprocess.PIPE)
     if s.stdout:
         for x in s.stdout.readlines():
-            if re.search(process, x.decode('ascii').strip()):
+            if re.search(process, x.decode().strip()):
                 return True
     return False
 
@@ -438,7 +438,7 @@ def _wm_set_background(wallpaper_path: Path | str):
                             sys.stderr.write("Couldn't find any x11 displays")
                         return
                     for x in s.stdout.readlines():
-                        display = x.decode('ascii').strip()
+                        display = x.decode().strip()
                         args += "nitrogen --head=%s --set-zoom-fill %s && " % (display, wallpaper_path)
                     args += ":"  # bash no-op
                     break

--- a/EdgeWare/utils/linux.py
+++ b/EdgeWare/utils/linux.py
@@ -179,8 +179,18 @@ def set_wallpaper(wallpaper_path: Path | str):
             # From http://www.commandlinefu.com/commands/view/3857/set-wallpaper-on-windowmaker-in-one-line
             args = "wmsetbg -s -u %s" % wallpaper_path
             subprocess.Popen(args, shell=True)
-        elif desktop_env in ["i3", "awesome", "hyprland"]:
+        elif desktop_env in ["i3", "awesome", "dwm", "xmonad", "bspwm"]:
             _wm_set_background(wallpaper_path)        
+        elif desktop_env == "Hyprland":
+            if not shutil.which("hyprctl"):
+                if first_run:
+                    sys.stderr.write("hyprpaper requires hyprctl.")
+                return False
+            args = "hyprctl hyprpaper wallpaper \",%s\"" % wallpaper_path
+            subprocess.Popen(args, shell=True)
+        elif desktop_env == "sway":
+            args = "swaybg -o \"*\" -i %s -m fill" % wallpaper_path
+            subprocess.Popen(args, shell=True)
         ## NOT TESTED BELOW - don't want to mess things up ##
         # elif desktop_env=='enlightenment': # I have not been able to make it work on e17. On e16 it would have been something in this direction
         #    args = 'enlightenment_remote -desktop-bg-add 0 0 0 0 %s' % wallpaper_path
@@ -398,11 +408,9 @@ def _wm_set_background(wallpaper_path: Path | str):
             "display", # not tested
             #"xsetroot", # only solid colors
         ]
+    # may not need this actually
     elif session == "wayland":
-        wallpaper_setters = [
-            "hyprpaper",
-            "swaybg"  # not tested
-        ]
+        wallpaper_setters = []
     else:
         sys.stderr.write("Unknown session: %s" % session)
     # perform commands based on the wallpaper setter
@@ -478,16 +486,6 @@ def _wm_set_background(wallpaper_path: Path | str):
                             sys.stderr.write("display needs xwininfo to query the size of the root window.")
                         return
                     args = "display -sample `xwininfo -root 2> /dev/null|awk '/geom/{print $2}'` -window root"
-                    break
-                case "hyprpaper":
-                    if not shutil.which("hyprctl"):
-                        if first_run:
-                            sys.stderr.write("hyprpaper requires hyprctl.")
-                        return
-                    args = "hyprctl hyprpaper wallpaper \",%s\"" % wallpaper_path
-                    break
-                case "swaybg":
-                    args = "swaybg -o \"*\" -i %s -m fill" % wallpaper_path
                     break
                 case _:
                     sys.stderr.write("Tell the developer they \"forgot to add a case for %s\"" % setter)


### PR DESCRIPTION
Fixes:
 - VLC now spawns videos in Tk Labels correctly
 - Use $XDG_CURRENT_DESKTOP as primary session identifier and $DESKTOP_SESSION as a backup
 - Panic script correctly SIGKILLs all processes matching "python.* *+.pyw"

Additions:
- Function `_wm_set_background()` based on [awsetbg](https://github.com/paul/awesome/blob/master/utils/awsetbg) to find background setting programs for window managers without full desktop environments 
  - X11/Wayland checking to prevent setting X11 wallpaper on Wayland and vice-versa
- Window managers to desktop environment list
  - i3
  - awesome
  - dwm
  - xmonad
  - bspwm
  - Hyprland
  - sway
- Wallpaper setters in `_wm_set_background()`  for X11
  - nitrogen
  - feh
  - habak
  - hsetroot
  - chbg
  - qiv
  - xv
  - xsri
  - xli
  - xsetbg
  - fvwm-root
  - wmsetbg
  - Esetroot
  - display

**I've only tested i3 (feh & nitrogen) and Hyprland (hyprpaper).** Hyprland is still very scuffed since hyprpaper completely shatters and requires a re-login if you try to preload the wrong filetype as a wallpaper (incredible). Feh and nitrogen work fine. I'll update this or make another PR when I have time to test the rest of them if someone else hasn't when I get around to it.

Happy to do any corrections or code formatting.