### PR TITLE
Fixed fill, added random fill functionality and .bat file to run the script as Admin

### DIFF
--- a/edgeware/Admin.bat
+++ b/edgeware/Admin.bat
@@ -1,0 +1,17 @@
+@echo off
+
+:: Get the path of the current directory
+set script_dir=%~dp0
+
+:: Check for administrator privileges
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Requesting administrator privileges...
+    powershell -Command "Start-Process '%~f0' -Verb runAs"
+    exit /b
+)
+
+:: Run the Python script with administrator privileges
+python "%script_dir%edgeware.pyw"
+
+pause

--- a/edgeware/assets/default_config.json
+++ b/edgeware/assets/default_config.json
@@ -3,6 +3,7 @@
   "versionplusplus": "14.2",
   "delay": 5000,
   "fill": 0,
+  "random_fill": 0,
   "replace": 0,
   "webMod": 0,
   "popupMod": 100,

--- a/edgeware/src/config.py
+++ b/edgeware/src/config.py
@@ -2041,7 +2041,14 @@ class Config(Tk):
             command=lambda: set_widget_states(vars.fill_drive.get(), fill_group),
             cursor="question_arrow",
         )
-        fillDelay = Scale(fillFrame, label="Fill Delay (10ms)", from_=0, to=250, orient="horizontal", variable=vars.fill_delay)
+        random_fillBox = Checkbutton(
+            fillFrame,
+            text="Random Filling",
+            variable=vars.random_fill,
+            command=lambda: vars.random_fill.get(),
+            cursor="question_arrow",
+        )
+        fillDelay = Scale(fillFrame, label="Fill Delay (10ms increments)", from_=0, to=1000, orient="horizontal", variable=vars.fill_delay)
 
         fillttp = CreateToolTip(
             fillBox,
@@ -2050,9 +2057,18 @@ class Config(Tk):
             "names listed in the folder name blacklist.\nIt will also ONLY place images into the User folder and its subfolders.\nFill drive has "
             "one modifier, which is its own forced delay. Because it runs with between 1 and 8 threads at any given time, when improperly configured it can "
             "fill your drive VERY quickly. To ensure that you get that nice slow fill, you can adjust the delay between each folder sweep it performs.",
+            "If you want to fill folders in a privileged folder such as C:, you need to run the script as admin using Admin.bat",
         )
 
+        random_fillttp = CreateToolTip(
+            random_fillBox,
+            'Normally the specified directory and its subdirectories are filled in order, in a deterministic way, so if you '
+            'want to undo the filling, using the debugger and some print statements, you can get an idea of how the folders '
+            'were filled and you can go through them to delete the images. If you turn this on you won\'t be able to do this '
+            'and finding the images will be a pain. You were warned.',
+        )
         fill_group.append(fillDelay)
+        fill_group.append(random_fillBox)
 
         replaceBox = Checkbutton(
             fillFrame,
@@ -2100,6 +2116,7 @@ class Config(Tk):
         hardDriveFrame.pack(fill="x")
         fillFrame.pack(fill="y", side="left")
         fillBox.pack()
+        random_fillBox.pack()
         fillDelay.pack()
         replaceFrame.pack(fill="y", side="left")
         replaceBox.pack()

--- a/edgeware/src/config_window/vars.py
+++ b/edgeware/src/config_window/vars.py
@@ -15,6 +15,8 @@ class Vars:
         self.audio_chance = self.make(IntVar, "audioMod")
         self.prompt_chance = self.make(IntVar, "promptMod")
         self.fill_drive = self.make(BooleanVar, "fill")
+        self.random_fill =  self.make(BooleanVar, "random_fill")
+
 
         self.fill_delay = self.make(IntVar, "fill_delay")
         self.replace_images = self.make(BooleanVar, "replace")

--- a/edgeware/src/features/drive.py
+++ b/edgeware/src/features/drive.py
@@ -15,7 +15,7 @@ from state import State
 
 def filter_avoid_list(settings: Settings, dirs: list[str]) -> None:
     for dir in dirs.copy():
-        if dir in settings.drive_avoid_list or dir[0] == ".":
+        if dir in settings.drive_avoid_list or dir.startswith(('.', '$')):
             dirs.remove(dir)
 
 
@@ -28,6 +28,8 @@ def fill_drive(root: Tk, settings: Settings, pack: Pack, state: State) -> None:
     for path, dirs, files in os.walk(settings.drive_path):
         filter_avoid_list(settings, dirs)
         paths.append(Path(path))
+    if settings.random_fill:
+        random.shuffle(paths)
 
     def fill() -> None:
         if len(paths) == 0:

--- a/edgeware/src/settings.py
+++ b/edgeware/src/settings.py
@@ -129,6 +129,7 @@ class Settings:
         # Dangerous
         self.drive_avoid_list = self.config["avoidList"].split(">")  # TODO: Store in a better way
         self.fill_drive = bool(self.config["fill"])
+        self.random_fill = bool(self.config["random_fill"])
         self.drive_path = self.config["drivePath"]
         self.fill_delay = int(self.config["fill_delay"]) * 10  # Milliseconds
         self.replace_images = bool(self.config["replace"])


### PR DESCRIPTION
-Fixed the fill function (There was an issue when selecting a folder such as E: to fill - since the function tried filling the subdirectories in order and the first subdirectory is $RECOVERY, which requires Admin permission to write to, the fill function would not work until the for loop finished iterating over these subdirectories). Added a .startswith(('.', '$')) check to avoid directories starting with . and $ and prevent this unnecessary delay in the filling process.

-Added Random Filling functionality. Normally the filling process is deterministic, the directories and subdirectories are filled in alphabetical order, making it easy to track what was filled and delete the images. Enabling this setting will fill the directories and subdirectories in a random manner, making it much more annoying to track what was filled, considering a drive such as C: can have 10k + directories. -Added Admin.bat script which runs edgeware.pyw with Admin privileges, which allows filling drives and directories that require elevated permissions to write to.