### PR TITLE
fix: return first monitor when no primary monitor

### DIFF
--- a/edgeware/src/utils.py
+++ b/edgeware/src/utils.py
@@ -57,8 +57,9 @@ def compute_mood_id(paths: PackPaths) -> str:
     return md5(str(sorted(data)).encode()).hexdigest()
 
 
-def primary_monitor() -> Monitor:
-    return next(m for m in get_monitors() if m.is_primary)
+def primary_monitor() -> Monitor | None:
+    monitors = get_monitors()
+    return next((m for m in monitors if m.is_primary), monitors[0] if monitors else None)
 
 
 def random_monitor(settings: Settings) -> Monitor:


### PR DESCRIPTION
This patch changes the `primary_monitor()` function to return the first monitor when no primary monitor is set. I believe this is an xwayland issue with having no primary monitors, but it is guaranteed not to cause problems as long as a monitor exists. Additionally, it returns `None` when no monitors exist.

See example in image below.

<img width="643" height="167" alt="ew" src="https://github.com/user-attachments/assets/cd266ebb-6e18-48ac-801e-1772ff6734f2" />
