### PR TITLE
Fix popup opacity for KDE Plasma

### DIFF
--- a/edgeware/src/os_utils/linux.py
+++ b/edgeware/src/os_utils/linux.py
@@ -36,10 +36,12 @@ def close_mpv(player: mpv.MPV) -> None:
 
 
 def set_borderless(window: Toplevel) -> None:
+
+    window.attributes("-type", "splash")
+
     if get_desktop_environment() == "kde":
+        # below needed to ensure popups remain on top in KDE Plasma
         window.overrideredirect(True)
-    else:
-        window.attributes("-type", "splash")
 
 
 def set_clickthrough(window: Toplevel) -> None:


### PR DESCRIPTION
Implementing fix discussed for this issue: https://github.com/araten10/EdgewarePlusPlus/issues/282

Tested with multiple users on Wayland. Haven't tested on x11, but KDE Plasma seems to be dropping x11 support soon anyway