### PR TITLE
Prompt Popups working on KDE Plasma (and maybe other DEs)

### DIFF
--- a/edgeware/src/os_utils/linux.py
+++ b/edgeware/src/os_utils/linux.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 import mpv
 from config import load_default_config
 from paths import CustomAssets, Process
+from features.prompt import Prompt
 
 from os_utils.linux_utils import find_get_wallpaper_command, find_set_wallpaper_commands, find_set_wallpaper_function, get_desktop_environment
 
@@ -34,14 +35,30 @@ from os_utils.linux_utils import find_get_wallpaper_command, find_set_wallpaper_
 def close_mpv(player: mpv.MPV) -> None:
     player.stop()
 
-
 def set_borderless(window: Toplevel) -> None:
-
-    window.attributes("-type", "splash")
-
     if get_desktop_environment() == "kde":
+
+        # windows that use overrideredirect(true) can't take focus (https://core.tcl-lang.org/tk/artifact/7892c68f49012d2d71222ae0e312a1e7dc69a801?txt=1&ln=51-64)
+        # so prompt windows need to be treated as a special case
+        if isinstance(window, Prompt):
+
+            window.title("PROMPT")
+
+            # remove min, max and close buttons
+            window.attributes("-type", "toolbar")
+
+            window.resizable(False, False)
+
+            return
+
+        # below needed to ensure popups can have transparency
+        window.attributes("-type", "splash")
+
         # below needed to ensure popups remain on top in KDE Plasma
         window.overrideredirect(True)
+    else:
+        window.attributes("-type", "splash")
+
 
 
 def set_clickthrough(window: Toplevel) -> None:


### PR DESCRIPTION
This is a fix for https://github.com/araten10/EdgewarePlusPlus/issues/162 on KDE Plasma, but I think a similar approach could be used for other desktop environments with the same issue. This also preserves the changes made in https://github.com/araten10/EdgewarePlusPlus/commit/1d880348ab6c25e8a27fa114152985e5d62675e6

Thanks to TotallyNotAnAccount's feedback on the original thread I abandoned trying to get the prompts to work with `overrideredirect(True)`. The approach I settled on creates Prompt Popups with the following:

- a bordered window with its own icon in the task bar (tradeoff)
- min, max and close buttons removed from the window border
- window cannot be closed through the task bar
- non-resizeable
- renders below Popups but above all other windows (tradeoff)
- can be moved around with the mouse (tradeoff, couldn't find a simple way to disable this)
- can now take focus and receive text input

Tested on Wayland

<img width="473" height="561" alt="image" src="https://github.com/user-attachments/assets/5a6c9592-0ea4-40fb-a134-cb70905ab9ac" />
